### PR TITLE
Added getMaxQty...

### DIFF
--- a/src/OrderFulfillments.php
+++ b/src/OrderFulfillments.php
@@ -182,7 +182,7 @@ class OrderFulfillments extends Plugin
                 /* @var LineItem $lineItem */
                 foreach ($order->getLineItems() as $lineItem) {
                     $fulfillableQty = $this->getFulfillmentLines()->getFulfillableQty($lineItem, $limitToStock = true);
-                    $maxfulfillableQty = $this->getFulfillmentLines()->getFulfillableQty($lineItem);
+                    $maxfulfillableQty = $this->getFulfillmentLines()->getFulfillableQty($lineItem, $limitToStock = false, $getMaxQty = true);
 
                     $fulfillmentLines[] = [
                         'id' => $lineItem->id,

--- a/src/events/FulfillableQtyEvent.php
+++ b/src/events/FulfillableQtyEvent.php
@@ -46,5 +46,10 @@ class FulfillableQtyEvent extends CancelableEvent
      */
     public $limitToStock;
 
+    /**
+     * @var boolean to retrieve the max quantity of an item
+     */
+    public $getMaxQty;
+
 
 }

--- a/src/models/FulfillmentLine.php
+++ b/src/models/FulfillmentLine.php
@@ -153,7 +153,7 @@ class FulfillmentLine extends Model
             ['fulfilledQty', function($attribute) {
                 $maxQty = OrderFulfillments::getInstance()
                     ->getFulfillmentLines()
-                    ->getFulfillableQty($this->getLineItem());
+                    ->getFulfillableQty($this->getLineItem(), false, true);
 
                 if ($this->$attribute > $maxQty) {
                     $this->addError($attribute, Craft::t('order-fulfillments', 'You can only fulfill {number} of this item.', [

--- a/src/services/FulfillmentLines.php
+++ b/src/services/FulfillmentLines.php
@@ -166,13 +166,15 @@ class FulfillmentLines extends Component
      * @param Boolean $limitToStock
      * @return int
      */
-    public function getFulfillableQty(LineItem $lineItem, $limitToStock = false): int
+    public function getFulfillableQty(LineItem $lineItem, $limitToStock = false, $getMaxQty = false): int
     {
         $fulfillmentItems = $this->getFulfillmentLinesByLineItem($lineItem);
 
         $quantity = $lineItem->qty;
-        foreach ($fulfillmentItems as $fulfillmentItem) {
-            $quantity -= $fulfillmentItem->fulfilledQty;
+        if (!$getMaxQty) {
+            foreach ($fulfillmentItems as $fulfillmentItem) {
+                $quantity -= $fulfillmentItem->fulfilledQty;
+            }
         }
 
         $event = new FulfillableQtyEvent([
@@ -180,6 +182,7 @@ class FulfillmentLines extends Component
             'fulfillmentItems' => $fulfillmentItems,
             'quantity' => $quantity,
             'limitToStock' => $limitToStock,
+            'getMaxQty' => $getMaxQty,
         ]);
 
         // Raise a 'getFulfillableQty' event

--- a/src/templates/_includes/fulfillments.html
+++ b/src/templates/_includes/fulfillments.html
@@ -35,6 +35,10 @@
                     <tbody>
                         {% for fulfillmentLine in fulfillment.fulfillmentLines %}
                             {% set lineItem = fulfillmentLine.lineItem %}
+                            {% set maxQty = craft.fulfillments
+                                .getPlugin()
+                                .getFulfillmentLines()
+                                .getFulfillableQty(lineItem, false, true) %}
 
                             <tr class="infoRow">
                                 <td data-title="{{ 'Item' | t('order-fulfillments') }}">
@@ -46,7 +50,7 @@
                                 </td>
 
                                 <td data-title="{{ 'Quantity' | t('order-fulfillments') }}">
-                                    {{ fulfillmentLine.fulfilledQty }} of {{ lineItem.qty }}
+                                    {{ fulfillmentLine.fulfilledQty }} of {{ maxQty }}
                                 </td>
                             </tr>
                         {% endfor %}


### PR DESCRIPTION
Added getMaxQty so that getting the max quantity of a line item can be extended.
I have implemented a basic refund system so I needed the max quantity to reflect the actual qty ordered minus any refunded items.